### PR TITLE
Updated and improved support for tvOS

### DIFF
--- a/cocos2d/CCAction.m
+++ b/cocos2d/CCAction.m
@@ -328,10 +328,10 @@
 			return;
 
 		CGPoint tempPos = ccpSub( _halfScreenSize, _followedNode.position);
-		[_target setPosition:ccp(clampf(tempPos.x, _leftBoundary, _rightBoundary), clampf(tempPos.y, _bottomBoundary, _topBoundary))];
+		[(CCNode*)_target setPosition:ccp(clampf(tempPos.x, _leftBoundary, _rightBoundary), clampf(tempPos.y, _bottomBoundary, _topBoundary))];
 	}
 	else
-		[_target setPosition:ccpSub( _halfScreenSize, _followedNode.position )];
+		[(CCNode*)_target setPosition:ccpSub( _halfScreenSize, _followedNode.position )];
 }
 
 

--- a/cocos2d/CCActionCamera.m
+++ b/cocos2d/CCActionCamera.m
@@ -38,7 +38,7 @@
 -(void) startWithTarget:(id)aTarget
 {
 	[super startWithTarget:aTarget];
-	CCCamera *camera = [_target camera];
+	CCCamera *camera = [(CCNode*)_target camera];
 	[camera centerX:&_centerXOrig centerY:&_centerYOrig centerZ:&_centerZOrig];
 	[camera eyeX:&_eyeXOrig eyeY:&_eyeYOrig eyeZ:&_eyeZOrig];
 	[camera upX:&_upXOrig upY:&_upYOrig upZ: &_upZOrig];
@@ -112,7 +112,7 @@
 	float j = sinf(za) * sinf(xa) * r + _centerYOrig;
 	float k = cosf(za) * r + _centerZOrig;
 
-	[[_target camera] setEyeX:i eyeY:j eyeZ:k];
+	[[(CCNode*)_target camera] setEyeX:i eyeY:j eyeZ:k];
 }
 
 -(void) sphericalRadius:(float*) newRadius zenith:(float*) zenith azimuth:(float*) azimuth
@@ -121,7 +121,7 @@
 	float r; // radius
 	float s;
 
-	CCCamera *camera = [_target camera];
+	CCCamera *camera = [(CCNode*)_target camera];
 	[camera eyeX:&ex eyeY:&ey eyeZ:&ez];
 	[camera centerX:&cx centerY:&cy centerZ:&cz];
 

--- a/cocos2d/CCActionCatmullRom.m
+++ b/cocos2d/CCActionCatmullRom.m
@@ -277,7 +277,7 @@ inline CGPoint ccCardinalSplineAt( CGPoint p0, CGPoint p1, CGPoint p2, CGPoint p
 
 -(void) updatePosition:(CGPoint)newPos
 {
-	[_target setPosition:newPos];
+	[(CCNode*)_target setPosition:newPos];
 	_previousPosition = newPos;
 }
 
@@ -303,7 +303,7 @@ inline CGPoint ccCardinalSplineAt( CGPoint p0, CGPoint p1, CGPoint p2, CGPoint p
 -(void) updatePosition:(CGPoint)newPos
 {
 	CGPoint p = ccpAdd(newPos, _startPosition);
-	[_target setPosition:p];
+	[(CCNode*)_target setPosition:p];
 	_previousPosition = p;
 }
 

--- a/cocos2d/CCActionInterval.m
+++ b/cocos2d/CCActionInterval.m
@@ -651,7 +651,7 @@
 @implementation CCMoveBy
 +(id) actionWithDuration: (ccTime) t position: (CGPoint) p
 {
-	return [[[self alloc] initWithDuration:t position:p ] autorelease];
+	return [[[CCMoveBy alloc] initWithDuration:t position:p ] autorelease];
 }
 
 -(id) initWithDuration: (ccTime) t position: (CGPoint) p
@@ -687,7 +687,7 @@
 	CGPoint diff = ccpSub(currentPos, _previousPos);
 	_startPos = ccpAdd( _startPos, diff);
 	CGPoint newPos =  ccpAdd( _startPos, ccpMult(_positionDelta, t) );
-	[_target setPosition: newPos];
+	[(CCNode*)_target setPosition: newPos];
 	_previousPos = newPos;
 #else
 	[node setPosition: ccpAdd( _startPos, ccpMult(_positionDelta, t))];

--- a/cocos2d/CCConfiguration.h
+++ b/cocos2d/CCConfiguration.h
@@ -56,11 +56,17 @@ enum {
 	kCCDeviceiPhoneRetinaDisplay,
 	kCCDeviceiPhone5,
 	kCCDeviceiPhone5RetinaDisplay,
+	kCCDeviceiPhone6,
+	kCCDeviceiPhoneRetinaHDDisplay,
 	kCCDeviceiPad,
 	kCCDeviceiPadRetinaDisplay,
 
 	kCCDeviceMac,
 	kCCDeviceMacRetinaDisplay,
+    
+#if defined(__TV_OS_VERSION_MAX_ALLOWED)
+    kCCDeviceTVDisplay
+#endif
 };
 
 /**

--- a/cocos2d/CCConfiguration.m
+++ b/cocos2d/CCConfiguration.m
@@ -129,7 +129,9 @@ static char * glExtensions;
 -(NSInteger) runningDevice
 {
 	NSInteger ret=-1;
-	
+#if defined(__TV_OS_VERSION_MAX_ALLOWED)
+    ret = kCCDeviceTVDisplay;
+#else
 #ifdef __CC_PLATFORM_IOS
 	
 	if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
@@ -138,13 +140,19 @@ static char * glExtensions;
 	}
 	else if( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone )
 	{
-		// From http://stackoverflow.com/a/12535566
-		BOOL isiPhone5 = CGSizeEqualToSize([[UIScreen mainScreen] preferredMode].size,CGSizeMake(640, 1136));
-		
-		if( CC_CONTENT_SCALE_FACTOR() == 2 ) {
-			ret = isiPhone5 ? kCCDeviceiPhone5RetinaDisplay : kCCDeviceiPhoneRetinaDisplay;
-		} else
-			ret = isiPhone5 ? kCCDeviceiPhone5 : kCCDeviceiPhone;
+        if( CC_CONTENT_SCALE_FACTOR() == 2 ) {
+            if (([[CCDirector sharedDirector] winSize].width == 568) || ([[CCDirector sharedDirector] winSize].height == 568)) {
+                ret = kCCDeviceiPhone5RetinaDisplay;
+            } else if (([[CCDirector sharedDirector] winSize].width == 667) || ([[CCDirector sharedDirector] winSize].height == 667)) {
+                ret = kCCDeviceiPhone6;
+            } else {
+                ret = kCCDeviceiPhoneRetinaDisplay;
+            }
+        } else if ( CC_CONTENT_SCALE_FACTOR() == 3) {
+            ret = kCCDeviceiPhoneRetinaHDDisplay;
+        } else {
+            ret = kCCDeviceiPhone;
+        }
 	}
 	
 #elif defined(__CC_PLATFORM_MAC)
@@ -153,7 +161,8 @@ static char * glExtensions;
 	ret = kCCDeviceMac;
 	
 #endif // __CC_PLATFORM_MAC
-	
+#endif
+    
 	return ret;
 }
 

--- a/cocos2d/CCGLProgram.m
+++ b/cocos2d/CCGLProgram.m
@@ -73,12 +73,12 @@ typedef void (*GLLogFunction) (GLuint program,
 
 + (id)programWithVertexShaderByteArray:(const GLchar*)vShaderByteArray fragmentShaderByteArray:(const GLchar*)fShaderByteArray
 {
-	return [[[self alloc] initWithVertexShaderByteArray:vShaderByteArray fragmentShaderByteArray:fShaderByteArray] autorelease];
+	return [[[CCGLProgram alloc] initWithVertexShaderByteArray:vShaderByteArray fragmentShaderByteArray:fShaderByteArray] autorelease];
 }
 
 + (id)programWithVertexShaderFilename:(NSString *)vShaderFilename fragmentShaderFilename:(NSString *)fShaderFilename
 {
-	return [[[self alloc] initWithVertexShaderFilename:vShaderFilename fragmentShaderFilename:fShaderFilename] autorelease];
+	return [[[CCGLProgram alloc] initWithVertexShaderFilename:vShaderFilename fragmentShaderFilename:fShaderFilename] autorelease];
 }
 
 - (id)initWithVertexShaderByteArray:(const GLchar *)vShaderByteArray fragmentShaderByteArray:(const GLchar *)fShaderByteArray

--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -155,6 +155,7 @@
 
 - (NSString*) getFontName:(NSString*)fontName
 {
+#ifdef __CC_PLATFORM_MAC
 	// Custom .ttf file ?
     if ([[fontName lowercaseString] hasSuffix:@".ttf"])
     {
@@ -165,6 +166,7 @@
 
 		return [[fontFile lastPathComponent] stringByDeletingPathExtension];
     }
+#endif //
 
     return fontName;
 }

--- a/cocos2d/CCLayer.m
+++ b/cocos2d/CCLayer.m
@@ -724,7 +724,7 @@
 
 	// Compressed Interpolation mode
 	if( _compressedInterpolation ) {
-		float h2 = 1 / ( fabsf(u.x) + fabsf(u.y) );
+		float h2 = 1 / ( fabs(u.x) + fabs(u.y) );
 		u = ccpMult(u, h2 * (float)c);
 	}
 

--- a/cocos2d/CCProtocols.h
+++ b/cocos2d/CCProtocols.h
@@ -130,9 +130,11 @@
 /** Called by CCDirector when the projection is updated, and "custom" projection is used */
 -(void) updateProjection;
 
-#if defined(__CC_PLATFORM_IOS) && !defined(__TV_OS_VERSION_MAX_ALLOWED)
+#if defined(__CC_PLATFORM_IOS)
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
 /** Returns a Boolean value indicating whether the CCDirector supports the specified orientation. Default value is YES (supports all possible orientations) */
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
+#endif
 
 // Commented. See issue #1453 for further info: http://code.google.com/p/cocos2d-iphone/issues/detail?id=1453
 //- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration;

--- a/cocos2d/CCSpriteFrameCache.m
+++ b/cocos2d/CCSpriteFrameCache.m
@@ -386,7 +386,7 @@ static CCSpriteFrameCache *_sharedSpriteFrameCache=nil;
 
 	for (NSString *spriteFrameKey in _spriteFrames)
 	{
-		if ([[_spriteFrames valueForKey:spriteFrameKey] texture] == texture)
+		if ([(CCSpriteFrame*)[_spriteFrames valueForKey:spriteFrameKey] texture] == texture)
 			[keysToRemove addObject:spriteFrameKey];
 
 	}

--- a/cocos2d/CCTexture2D.m
+++ b/cocos2d/CCTexture2D.m
@@ -483,24 +483,20 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
     
     if (definition.dimensions.width == 0 || definition.dimensions.height == 0)
     {
-//        CGSize boundingSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-//        CGSize dim = [string sizeWithFont:uifont
-//                 constrainedToSize:boundingSize
-//                     lineBreakMode:NSLineBreakByWordWrapping];
+        CGSize boundingSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+        CGSize dim;
         
-        CGSize size = [string sizeWithAttributes:
-                       @{NSFontAttributeName: uifont}];
-        
-//        CGRect textRect = [string boundingRectWithSize:boundingSize
-//                                             options:NSStringDrawingUsesLineFragmentOrigin
-//                                          attributes:@{NSFontAttributeName:uifont}
-//                                             context:nil];
-//        
-//        CGSize dim = CGSizeMake(ceilf(textRect.size.width), ceilf(textRect.size.height));
-        
-        // Values are fractional -- you should take the ceilf to get equivalent values
-        CGSize dim = CGSizeMake(ceilf(size.width), ceilf(size.height));
-        
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
+        dim = [string sizeWithFont:uifont
+                        constrainedToSize:boundingSize
+                            lineBreakMode:NSLineBreakByWordWrapping];
+#else
+        NSDictionary *tdic = [NSDictionary dictionaryWithObjectsAndKeys:uifont, NSFontAttributeName, nil];
+        dim = [string boundingRectWithSize:boundingSize
+                                  options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                               attributes:tdic
+                                  context:nil].size;
+#endif        
         
         if(dim.width == 0)
             dim.width = 1;
@@ -538,8 +534,8 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
     
     if ( [definition shadowEnabled] )
     {
-        shadowStrokePaddingX = max(shadowStrokePaddingX, (float)abs([definition shadowOffset].width));
-        shadowStrokePaddingY = max(shadowStrokePaddingY, (float)abs([definition shadowOffset].height));
+        shadowStrokePaddingX = max(shadowStrokePaddingX, (float)fabs([definition shadowOffset].width));
+        shadowStrokePaddingY = max(shadowStrokePaddingY, (float)fabs([definition shadowOffset].height));
     }
     
     // add the padding (this could be 0 if no shadow and no stroke)
@@ -641,7 +637,7 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
                                      };
         
         CGRect textRect = [string boundingRectWithSize:computedDimension
-                                             options:NSStringDrawingUsesLineFragmentOrigin
+                                             options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
                                           attributes:attributes
                                              context:nil];
         
@@ -661,19 +657,25 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
 	// must follow the same order of CCTextureAligment
 	NSUInteger alignments[] = { NSTextAlignmentLeft, NSTextAlignmentCenter, NSTextAlignmentRight };
     
-    NSMutableParagraphStyle *paragraphStyle = [[[NSMutableParagraphStyle alloc] init] autorelease];
+    //  [string drawInRect:drawArea withFont:uifont lineBreakMode:linebreaks[definition.lineBreakMode] alignment:alignments[definition.alignment]];
+    //	[string drawInRect:drawArea withFont:uifont lineBreakMode:linebreaks[lineBreakMode] alignment:alignments[hAlignment]];
+    
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
+    if ([CCConfiguration sharedConfiguration].OSVersion >= kCCiOSVersion_6_0_0) {
+#endif
+        NSMutableParagraphStyle* paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
     paragraphStyle.lineBreakMode = linebreaks[definition.lineBreakMode];
     paragraphStyle.alignment = alignments[definition.alignment];
+        UIColor* color = [UIColor whiteColor];
+        id dict = @{NSFontAttributeName: uifont, NSParagraphStyleAttributeName: paragraphStyle,NSForegroundColorAttributeName:color};
+        [string drawInRect:drawArea withAttributes:dict];
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
+    }
+    else {
+        [string drawInRect:drawArea withFont:uifont lineBreakMode:linebreaks[definition.lineBreakMode] alignment:alignments[definition.alignment]];
+    }
+#endif
     
-    // Create the attributes dictionary with the font and paragraph style
-    NSDictionary *attributes = @{
-                                 NSFontAttributeName:uifont,
-                                 NSParagraphStyleAttributeName:paragraphStyle
-                                 };
-    
-    [string drawInRect:drawArea withAttributes:attributes];
-    
-
 	UIGraphicsPopContext();
 	
 	if (effectsEnabled)
@@ -754,7 +756,7 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
                                      };
         
         CGRect textRect = [string boundingRectWithSize:dimensions
-                                               options:NSStringDrawingUsesLineFragmentOrigin
+                                               options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
                                             attributes:attributes
                                                context:nil];
         
@@ -774,19 +776,24 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
 	// must follow the same order of CCTextureAligment
 	NSUInteger alignments[] = { NSTextAlignmentLeft, NSTextAlignmentCenter, NSTextAlignmentRight };
     
-    NSMutableParagraphStyle *paragraphStyle = [[[NSMutableParagraphStyle alloc] init] autorelease];
+    //   [string drawInRect:drawArea withFont:uifont lineBreakMode:linebreaks[lineBreakMode] alignment:alignments[hAlignment]];
+
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
+    if ([CCConfiguration sharedConfiguration].OSVersion >= kCCiOSVersion_6_0_0) {
+#endif
+        NSMutableParagraphStyle* paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
     paragraphStyle.lineBreakMode = linebreaks[lineBreakMode];
     paragraphStyle.alignment = alignments[hAlignment];
+        UIColor* color = [UIColor whiteColor];
+        id dict = @{NSFontAttributeName: uifont, NSParagraphStyleAttributeName: paragraphStyle,NSForegroundColorAttributeName:color};
+        [string drawInRect:drawArea withAttributes:dict];
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
+    }
+    else {
+        [string drawInRect:drawArea withFont:uifont lineBreakMode:linebreaks[lineBreakMode] alignment:alignments[hAlignment]];
+    }
+#endif
     
-    // Create the attributes dictionary with the font and paragraph style
-    NSDictionary *attributes = @{
-                                 NSFontAttributeName:uifont,
-                                 NSParagraphStyleAttributeName:paragraphStyle
-                                 };
-    
-    [string drawInRect:drawArea withAttributes:attributes];
-
-
 	UIGraphicsPopContext();
 
 #if CC_USE_LA88_LABELS
@@ -1158,7 +1165,7 @@ static CCTexture2DPixelFormat defaultAlphaPixel_format = kCCTexture2DPixelFormat
                                  };
     
     CGRect textRect = [string boundingRectWithSize:boundingSize
-                                           options:NSStringDrawingUsesLineFragmentOrigin
+                                           options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
                                         attributes:attributes
                                            context:nil];
     

--- a/cocos2d/CCTextureAtlas.m
+++ b/cocos2d/CCTextureAtlas.m
@@ -324,7 +324,7 @@
 	if( oldIndex == newIndex )
 		return;
 
-	NSUInteger howMany = labs( oldIndex - newIndex);
+	NSUInteger howMany = ( oldIndex - newIndex);
 	NSUInteger dst = oldIndex;
 	NSUInteger src = oldIndex + 1;
 	if( oldIndex > newIndex) {

--- a/cocos2d/Platforms/iOS/CCDirectorIOS.m
+++ b/cocos2d/Platforms/iOS/CCDirectorIOS.m
@@ -305,7 +305,7 @@ float	__ccContentScaleFactor = 1;
 -(BOOL) enableRetinaDisplay:(BOOL)enabled
 {
 	// Already enabled ?
-	if( enabled && __ccContentScaleFactor == 2 )
+    if( enabled && (__ccContentScaleFactor == 2 || __ccContentScaleFactor == 3) )
 		return YES;
 
 	// Already disabled
@@ -320,7 +320,7 @@ float	__ccContentScaleFactor = 1;
 	if ([[UIScreen mainScreen] scale] == 1.0)
 		return NO;
 
-	float newScale = enabled ? 2 : 1;
+	float newScale = enabled ? [[UIScreen mainScreen] scale] : 1;
 	[self setContentScaleFactor:newScale];
 
 	// Load Hi-Res FPS label
@@ -428,6 +428,7 @@ GLToClipTransform(kmMat4 *transformOut)
 	}
 }
 
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
 // Override to allow orientations other than the default portrait orientation.
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
@@ -437,6 +438,7 @@ GLToClipTransform(kmMat4 *transformOut)
 
 	return ret;
 }
+#endif
 
 // Commented. See issue #1453 for further info: http://code.google.com/p/cocos2d-iphone/issues/detail?id=1453
 //-(void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration

--- a/cocos2d/Support/CCFileUtils.h
+++ b/cocos2d/Support/CCFileUtils.h
@@ -39,6 +39,10 @@ extern NSString const *kCCFileUtilsiPhone5HD;
 extern NSString const *kCCFileUtilsMac;
 extern NSString const *kCCFileUtilsMacHD;
 
+#if defined(__TV_OS_VERSION_MAX_ALLOWED)
+extern NSString const *kCCFileUtilsTV;
+#endif
+
 extern NSString const *kCCFileUtilsDefaultSearchPath;
 
 enum {
@@ -367,6 +371,15 @@ enum {
  @since v2.0
  */
 -(BOOL) iPadRetinaDisplayFileExistsAtPath:(NSString*)filename;
+
+#if defined(__TV_OS_VERSION_MAX_ALLOWED)
+/** Returns whether or not a given filename exists with the TV suffix.
+ Only available on tvOS. Not supported on OS X or iOS.
+ @since v2.2
+ */
+-(BOOL) tvDisplayFileExistsAtPath:(NSString*)filename;
+
+#endif
 
 #endif // __CC_PLATFORM_MAC
 

--- a/cocos2d/ccDeprecated.m
+++ b/cocos2d/ccDeprecated.m
@@ -136,7 +136,9 @@ void ccGLUniformModelViewProjectionMatrix( CCGLProgram* program )
 }
 -(void) setIsAccelerometerEnabled:(BOOL)enabled
 {
+#if !defined(__TV_OS_VERSION_MAX_ALLOWED)
 	[self setAccelerometerEnabled:enabled];
+#endif
 }
 #elif __CC_PLATFORM_MAC
 -(void) setIsTouchEnabled:(BOOL)enabled

--- a/cocos2d/ccTypes.h
+++ b/cocos2d/ccTypes.h
@@ -326,7 +326,11 @@ typedef enum
 {
 	//! Unknown resolution type
 	kCCResolutionUnknown,
-#ifdef __CC_PLATFORM_IOS
+#if defined(__TV_OS_VERSION_MAX_ALLOWED)
+        //! TV resolution type
+        kCCResolutionTV,
+#endif
+#if defined(__CC_PLATFORM_IOS)
 	//! iPhone resolution type
 	kCCResolutioniPhone,
 	//! iPhone RetinaDisplay resolution type
@@ -335,6 +339,10 @@ typedef enum
 	kCCResolutioniPhone5,
 	//! iPhone 5 RetinaDisplay resolution type
 	kCCResolutioniPhone5RetinaDisplay,
+        //! iPhone 6 RetinaDisplay resolution type
+        kCCResolutioniPhone6RetinaDisplay,
+        //! iPhone Retina HD resolution type
+        kCCResolutioniPhoneRetinaHDDisplay,
 	//! iPad resolution type
 	kCCResolutioniPad,
 	//! iPad Retina Display resolution type

--- a/external/kazmath/src/mat4.c
+++ b/external/kazmath/src/mat4.c
@@ -101,8 +101,8 @@ int gaussj(kmMat4 *a, kmMat4 *b)
             if (ipiv[j] != 1) {
                 for (k = 0; k < n; k++) {
                     if (ipiv[k] == 0) {
-                        if (abs(get(a,j, k)) >= big) {
-                            big = abs(get(a,j, k));
+                        if (fabsf(get(a,j, k)) >= big) {
+                            big = fabsf(get(a,j, k));
                             irow = j;
                             icol = k;
                         }


### PR DESCRIPTION
- Fixed a number of compiler warnings being reported in Xcode 7.1
- Added in TV as a new device resolution - I hope I got this all right.  Certainly seems to work for me.
- In CCProtocols.h fixed the hiding of shouldAutorotate... so that it doesn't also hide directorDidReshapeProjection.
- In CCTexture2D, tried to make the string sizing able to work on both TV and iOS
- Support scale factor of 3 for the iPhone 6S
