### PR TITLE
Correction so that devices running iOS 7.0 and earlier don't crash.

### DIFF
--- a/cocos2d-ios.xcodeproj/project.pbxproj
+++ b/cocos2d-ios.xcodeproj/project.pbxproj
@@ -789,6 +789,10 @@
 		A0EFA880169CDFA4006D1B22 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D500B920D5A79C200DBA0E3 /* OpenGLES.framework */; };
 		A0EFA881169CDFA4006D1B22 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D500B990D5A79CF00DBA0E3 /* QuartzCore.framework */; };
 		A0EFA882169CDFA4006D1B22 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 503092B210447296005F7AFC /* libz.dylib */; };
+		D04555B71BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h in Headers */ = {isa = PBXBuildFile; fileRef = D04555B51BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h */; };
+		D04555B81BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h in Headers */ = {isa = PBXBuildFile; fileRef = D04555B51BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h */; };
+		D04555B91BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m in Sources */ = {isa = PBXBuildFile; fileRef = D04555B61BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m */; };
+		D04555BA1BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m in Sources */ = {isa = PBXBuildFile; fileRef = D04555B61BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m */; };
 		E0112F53120CB406006667F8 /* CCTransitionPageTurn.h in Headers */ = {isa = PBXBuildFile; fileRef = E0112F4F120CB406006667F8 /* CCTransitionPageTurn.h */; };
 		E0112F54120CB406006667F8 /* CCTransitionPageTurn.m in Sources */ = {isa = PBXBuildFile; fileRef = E0112F50120CB406006667F8 /* CCTransitionPageTurn.m */; };
 		E01E6D8C121F130E001A484F /* CCLabelBMFont.h in Headers */ = {isa = PBXBuildFile; fileRef = E01E6D8A121F130E001A484F /* CCLabelBMFont.h */; };
@@ -1270,6 +1274,8 @@
 		A0DA0BDD15BCFAD700E80A92 /* ccShader_PositionColorLengthTexture_vert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccShader_PositionColorLengthTexture_vert.h; sourceTree = "<group>"; };
 		A0EFA7AC169CDF9C006D1B22 /* libcocos2d_box2d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcocos2d_box2d.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0EFA886169CDFA4006D1B22 /* libcocos2d_chipmunk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcocos2d_chipmunk.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D04555B51BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CCNode+SFGestureRecognizers.h"; path = "external/GestureRecognizers/CCNode+SFGestureRecognizers.h"; sourceTree = "<group>"; };
+		D04555B61BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CCNode+SFGestureRecognizers.m"; path = "external/GestureRecognizers/CCNode+SFGestureRecognizers.m"; sourceTree = "<group>"; };
 		E0112F4F120CB406006667F8 /* CCTransitionPageTurn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCTransitionPageTurn.h; sourceTree = "<group>"; };
 		E0112F50120CB406006667F8 /* CCTransitionPageTurn.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CCTransitionPageTurn.m; sourceTree = "<group>"; };
 		E01E6D8A121F130E001A484F /* CCLabelBMFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CCLabelBMFont.h; sourceTree = "<group>"; };
@@ -1489,6 +1495,7 @@
 		501756090F335CE900624901 /* external */ = {
 			isa = PBXGroup;
 			children = (
+				D04555B41BBA88600064A8FD /* GestureRecognizers */,
 				A015BFAB13B826D800C73E76 /* kazmath */,
 				50E5F309110690D300E3FCF5 /* Chipmunk */,
 				5031650810277785003ACFE7 /* libpng */,
@@ -2050,6 +2057,15 @@
 			name = Profiling;
 			sourceTree = "<group>";
 		};
+		D04555B41BBA88600064A8FD /* GestureRecognizers */ = {
+			isa = PBXGroup;
+			children = (
+				D04555B51BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h */,
+				D04555B61BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m */,
+			);
+			name = GestureRecognizers;
+			sourceTree = "<group>";
+		};
 		E0BC7DA11342CE83001B4DCC /* Shaders */ = {
 			isa = PBXGroup;
 			children = (
@@ -2229,6 +2245,7 @@
 				A046E29714C1DB7D0005BBF2 /* CCGLView.h in Headers */,
 				A046E29914C1DB7E0005BBF2 /* CCWindow.h in Headers */,
 				A09AB76914EA12F7009C8B91 /* ccDeprecated.h in Headers */,
+				D04555B81BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h in Headers */,
 				A0A10B5714F3011F00FA38C1 /* ccGLStateCache.h in Headers */,
 				A0C87D1A14F9A3A100C0E8B2 /* NSThread+performBlock.h in Headers */,
 				A093FF09150E9BE00039327A /* ccShaders.h in Headers */,
@@ -2276,6 +2293,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D04555B71BBA888C0064A8FD /* CCNode+SFGestureRecognizers.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2949,6 +2967,7 @@
 				A093FF0A150E9BE00039327A /* ccShaders.m in Sources */,
 				A0A7A53D1514F27D00C8BD16 /* CCActionCatmullRom.m in Sources */,
 				A039EC00155C686B0061EE37 /* CCNode+Debug.m in Sources */,
+				D04555BA1BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m in Sources */,
 				A04FA967156303C600EC18D4 /* ccCArray.m in Sources */,
 				A0DA0BC415BCDCA200E80A92 /* CCDrawNode.m in Sources */,
 				A0D7D9D015E2E730000CA0C4 /* CCPhysicsDebugNode.m in Sources */,
@@ -2977,6 +2996,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D04555B91BBA888C0064A8FD /* CCNode+SFGestureRecognizers.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cocos2d/CCGLProgram.m
+++ b/cocos2d/CCGLProgram.m
@@ -155,7 +155,7 @@ typedef void (*GLLogFunction) (GLuint program,
     // BEGIN workaround for Xcode 7 ios9----
     BOOL hasExtension = NO;
     NSString *sourceStr = [NSString stringWithUTF8String:source];
-    if([sourceStr containsString:g_extensionStr]) {
+    if ([sourceStr rangeOfString:g_extensionStr].location != NSNotFound) {
         hasExtension = YES;
         NSArray *strs = [sourceStr componentsSeparatedByString:g_extensionStr];
         assert(strs.count == 2);

--- a/external/GestureRecognizers/CCNode+SFGestureRecognizers.h
+++ b/external/GestureRecognizers/CCNode+SFGestureRecognizers.h
@@ -1,0 +1,75 @@
+/*
+ * CCNode+SFGestureRecognizers for cocos2d: http://merowing.info
+ *
+ * https://github.com/krzysztofzablocki/CCNode-SFGestureRecognizers.git
+ *
+ * Copyright (c) 2012 Krzysztof Zabłocki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#import "cocos2d.h"
+
+//! do you want to use sf_method or just method, disable shorthand if you have problems with methods names duplication from other code
+#define SF_GESTURE_RECOGNIZERS_USE_SHORTHAND 1
+
+//! when you add gesture recognizer to any node it will set isTouchEnabled on this node
+#define SF_GESTURE_RECOGNIZERS_AUTO_ENABLE_TOUCH_ON_NEW_GESTURE_RECOGNIZER 0
+
+
+@interface UIGestureRecognizer (SFGestureRecognizers)
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+@property (nonatomic, readonly) CCNode *node;
+#else
+@property (nonatomic, readonly) CCNode *sf_node;
+#endif
+@end
+
+@interface CCNode (SFGestureRecognizers)
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+@property (nonatomic, assign) BOOL isTouchEnabled;
+@property (nonatomic, assign) CGRect touchRect;
+
+- (void)addGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer;
+- (void)removeGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer;
+- (NSArray*)gestureRecognizers;
+
+// check if point is in touch area, node is visible and running and isTouchEnabled is set 
+- (BOOL)isPointTouchableInArea:(CGPoint)pt;
+- (BOOL)isNodeInTreeTouched:(CGPoint)pt;
+
+// check if point is in touch area, node is visible and running, ignores isTouchEnabled
+- (BOOL)isPointInArea:(CGPoint)pt;
+#else
+@property (nonatomic, assign, setter=sf_setIsTouchEnabled:) BOOL sf_isTouchEnabled;
+@property (nonatomic, assign, setter=sf_setTouchRect:) CGRect sf_touchRect;
+
+- (void)sf_addGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer;
+- (void)sf_removeGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer;
+- (NSArray*)sf_gestureRecognizers;
+
+// check if point is in touch area, node is visible and running and isTouchEnabled is set 
+- (BOOL)sf_isPointTouchableInArea:(CGPoint)pt;
+- (BOOL)sf_isNodeInTreeTouched:(CGPoint)pt;
+
+// check if point is in touch area, node is visible and running, ignores isTouchEnabled
+- (BOOL)sf_isPointInArea:(CGPoint)pt;
+#endif
+@end

--- a/external/GestureRecognizers/CCNode+SFGestureRecognizers.m
+++ b/external/GestureRecognizers/CCNode+SFGestureRecognizers.m
@@ -1,0 +1,513 @@
+//
+//  CCNode+GestureRecognizers.m
+//  Kubik
+//
+//  Created by Krzysztof Zablocki on 2/12/12.
+//  Copyright (c) 2012 Krzysztof Zablocki. All rights reserved.
+//
+//
+//  ARC Helper
+//
+//  Version 1.2.2
+//
+//  Created by Nick Lockwood on 05/01/2012.
+//  Copyright 2012 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://gist.github.com/1563325
+//
+//  https://github.com/krzysztofzablocki/CCNode-SFGestureRecognizers.git
+//
+//  Krzysztof Zabłocki Added AH_BRIDGE(x) to bridge cast to void*
+
+#ifndef AH_RETAIN
+#if __has_feature(objc_arc)
+#define AH_RETAIN(x) (x)
+#define AH_RELEASE(x) (void)(x)
+#define AH_AUTORELEASE(x) (x)
+#define AH_SUPER_DEALLOC (void)(0)
+#define AH_BRIDGE(x) ((__bridge void*)x)
+#else
+#define __AH_WEAK
+#define AH_WEAK assign
+#define AH_RETAIN(x) [(x) retain]
+#define AH_RELEASE(x) [(x) release]
+#define AH_AUTORELEASE(x) [(x) autorelease]
+#define AH_SUPER_DEALLOC [super dealloc]
+#define AH_BRIDGE(x) (x)
+#endif
+#endif
+
+//  Weak reference support
+
+#ifndef AH_WEAK
+#if defined __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED > __IPHONE_4_3
+#define __AH_WEAK __weak
+#define AH_WEAK weak
+#else
+#define __AH_WEAK __unsafe_unretained
+#define AH_WEAK unsafe_unretained
+#endif
+#elif defined __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __MAC_OS_X_VERSION_MIN_REQUIRED > __MAC_10_6
+#define __AH_WEAK __weak
+#define AH_WEAK weak
+#else
+#define __AH_WEAK __unsafe_unretained
+#define AH_WEAK unsafe_unretained
+#endif
+#endif
+#endif
+
+//  ARC Helper ends
+
+#import "CCNode+SFGestureRecognizers.h"
+#import <objc/runtime.h>
+
+//! __ for internal use | check out SFExecuteOnDealloc for category on NSObject that allows the same ;)
+typedef void(^__SFExecuteOnDeallocBlock)(void);
+
+@interface __SFExecuteOnDealloc : NSObject
++ (id)executeBlock:(__SFExecuteOnDeallocBlock)aBlock onObjectDealloc:(id)aObject;
+- (id)initWithBlock:(__SFExecuteOnDeallocBlock)aBlock;
+@end
+
+@implementation __SFExecuteOnDealloc {
+@public
+  __SFExecuteOnDeallocBlock block;
+}
+
++ (id)executeBlock:(__SFExecuteOnDeallocBlock)aBlock onObjectDealloc:(id)aObject
+{
+  __SFExecuteOnDealloc *executor = [[self alloc] initWithBlock:aBlock];
+  objc_setAssociatedObject(aObject, AH_BRIDGE(executor), executor, OBJC_ASSOCIATION_RETAIN);
+  return AH_AUTORELEASE(executor);
+}
+
+- (id)initWithBlock:(__SFExecuteOnDeallocBlock)aBlock
+{
+  self = [super init];
+  if (self) {
+    block = [aBlock copy];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  if (block) {
+    block();
+  }
+  AH_RELEASE(block);
+  AH_SUPER_DEALLOC;
+}
+@end
+
+
+static NSString *const CCNodeSFGestureRecognizersArrayKey = @"CCNodeSFGestureRecognizersArrayKey";
+static NSString *const CCNodeSFGestureRecognizersTouchRect = @"CCNodeSFGestureRecognizersTouchRect";
+static NSString *const CCNodeSFGestureRecognizersTouchEnabled = @"CCNodeSFGestureRecognizersTouchEnabled";
+static NSString *const UIGestureRecognizerSFGestureRecognizersPassingDelegateKey = @"UIGestureRecognizerSFGestureRecognizersPassingDelegateKey";
+
+@interface __SFGestureRecognizersPassingDelegate : NSObject<UIGestureRecognizerDelegate> {
+@public
+  __AH_WEAK id <UIGestureRecognizerDelegate> originalDelegate;
+  __AH_WEAK CCNode *node;
+  void *deallocBlockKey;
+}
+@end
+
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+@implementation __SFGestureRecognizersPassingDelegate
+
+#pragma mark - UIGestureRecognizer Delegate handling
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+  CGPoint pt = [[CCDirector sharedDirector] convertToGL:[touch locationInView: [touch view]]];
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+  BOOL rslt = [node isPointTouchableInArea:pt];
+#else
+  BOOL rslt = [node sf_isPointTouchableInArea:pt];
+#endif
+  
+  //! we need to make sure that no other node ABOVE this one was touched, we want ONLY the top node with gesture recognizer to get callback
+  if( rslt )
+  {
+    CCNode* curNode = node;
+    CCNode* parent = node.parent;
+    while( curNode != nil && rslt)
+    {
+      CCNode* child;
+      BOOL nodeFound = NO;
+      CCARRAY_FOREACH(parent.children, child)
+      {
+        if( !nodeFound )
+        {
+          if( !nodeFound && curNode == child )
+            nodeFound = YES;
+          continue;
+        }
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+        if( [child isNodeInTreeTouched:pt])
+#else
+        if( [child sf_isNodeInTreeTouched:pt])          
+#endif
+        {
+          rslt = NO;
+          break;
+        }
+      }
+      
+      curNode = parent;
+      parent = curNode.parent;
+    }
+  }
+  
+  if( rslt && [originalDelegate respondsToSelector:@selector(gestureRecognizer:shouldReceiveTouch:)])
+    rslt = [originalDelegate gestureRecognizer:gestureRecognizer shouldReceiveTouch:touch];
+  
+  return rslt;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+  if ([originalDelegate respondsToSelector:@selector(gestureRecognizerShouldBegin:)]) {
+    return [originalDelegate gestureRecognizerShouldBegin:gestureRecognizer];
+  }
+  return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  if ([originalDelegate respondsToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]) {
+    return [originalDelegate gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
+  }
+  
+  return NO;
+}
+
+#pragma mark - Handling delegate change
+- (void)setDelegate:(id<UIGestureRecognizerDelegate>)aDelegate
+{
+  __SFGestureRecognizersPassingDelegate *passingDelegate = objc_getAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
+  if (passingDelegate) {
+    passingDelegate->originalDelegate = aDelegate;
+  } else {
+    [self performSelector:@selector(originalSetDelegate:) withObject:aDelegate];
+  }
+}
+
+- (id<UIGestureRecognizerDelegate>)delegate
+{
+  __SFGestureRecognizersPassingDelegate *passingDelegate = objc_getAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
+  if (passingDelegate) {
+    return passingDelegate->originalDelegate;
+  }
+  
+  //! no delegate yet so use original method
+  return [self performSelector: @selector(originalDelegate)];
+}
+@end
+
+
+@implementation UIGestureRecognizer (SFGestureRecognizers)
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+@dynamic node;
+#else
+@dynamic sf_node;
+#endif
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (CCNode*)node
+#else
+- (CCNode*)sf_node
+#endif
+{
+  __SFGestureRecognizersPassingDelegate *passingDelegate = objc_getAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
+  if (passingDelegate) {
+    return passingDelegate->node;
+  }
+  return nil;
+}
+@end
+
+
+@implementation CCNode (SFGestureRecognizers)
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+@dynamic isTouchEnabled;
+@dynamic touchRect;
+#else
+@dynamic sf_isTouchEnabled;
+@dynamic sf_touchRect;
+#endif
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (void)addGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer
+#else
+- (void)sf_addGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer
+#endif
+{
+  //! prepare passing gesture recognizer
+  __SFGestureRecognizersPassingDelegate *passingDelegate = [[__SFGestureRecognizersPassingDelegate alloc] init];
+  passingDelegate->originalDelegate = aGestureRecognizer.delegate;
+  passingDelegate->node = self;
+  aGestureRecognizer.delegate = passingDelegate;
+  //! retain passing delegate as it only lives as long as this gesture recognizer lives
+  objc_setAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), passingDelegate, OBJC_ASSOCIATION_RETAIN);
+  AH_RELEASE(passingDelegate);
+  
+  //! we need to swap gesture recognizer methods so that we can handle delegates nicely, but we also need to be able to call originalMethods if gesture isnt assigned to CCNode, do it only once in whole app
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Method originalGetter = class_getInstanceMethod([UIGestureRecognizer class], @selector(delegate));
+    Method originalSetter = class_getInstanceMethod([UIGestureRecognizer class], @selector(setDelegate:));
+    Method swappedGetter = class_getInstanceMethod([__SFGestureRecognizersPassingDelegate class], @selector(delegate));
+    Method swappedSetter = class_getInstanceMethod([__SFGestureRecognizersPassingDelegate class], @selector(setDelegate:));
+    
+    class_addMethod([UIGestureRecognizer class], @selector(originalDelegate), method_getImplementation(originalGetter), method_getTypeEncoding(originalGetter));
+    class_replaceMethod([UIGestureRecognizer class], @selector(delegate), method_getImplementation(swappedGetter), method_getTypeEncoding(swappedGetter));
+    class_addMethod([UIGestureRecognizer class], @selector(originalSetDelegate:), method_getImplementation(originalSetter), method_getTypeEncoding(originalSetter));
+    class_replaceMethod([UIGestureRecognizer class], @selector(setDelegate:), method_getImplementation(swappedSetter), method_getTypeEncoding(swappedSetter));
+  });
+  
+
+if ([[CCDirector sharedDirector] respondsToSelector:@selector(view)]) {
+  [[[CCDirector sharedDirector] performSelector:@selector(view)] addGestureRecognizer:aGestureRecognizer];
+} else {
+  [[[CCDirector sharedDirector] performSelector:@selector(openGLView)] addGestureRecognizer:aGestureRecognizer];
+}
+  //! add to array
+  NSMutableArray *gestureRecognizers = objc_getAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersArrayKey));
+  if (!gestureRecognizers) {
+    gestureRecognizers = [NSMutableArray array];
+    objc_setAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersArrayKey), gestureRecognizers, OBJC_ASSOCIATION_RETAIN);
+    
+  }
+  [gestureRecognizers addObject:aGestureRecognizer];
+
+  //! remove this gesture recognizer from view when array is deallocatd
+  __unsafe_unretained __block CCNode *weakSelf = self; 
+  void *key = AH_BRIDGE([__SFExecuteOnDealloc executeBlock:^{
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+    [weakSelf removeGestureRecognizer:aGestureRecognizer];
+#else
+    [weakSelf sf_removeGestureRecognizer:aGestureRecognizer];
+#endif
+  } onObjectDealloc:gestureRecognizers]);
+  
+  //! remember dealloc block key
+  passingDelegate->deallocBlockKey = key;
+
+#if SF_GESTURE_RECOGNIZERS_AUTO_ENABLE_TOUCH_ON_NEW_GESTURE_RECOGNIZER
+  //! enable touch for this element or it won't work
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+  [self setIsTouchEnabled:YES];
+#else
+  [self sf_setIsTouchEnabled:YES];
+#endif
+#endif
+}
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (void)removeGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer
+#else
+- (void)sf_removeGestureRecognizer:(UIGestureRecognizer*)aGestureRecognizer
+#endif
+{
+  NSMutableArray *gestureRecognizers = objc_getAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersArrayKey));
+  
+  //! remove dealloc block
+  __SFGestureRecognizersPassingDelegate *delegate = objc_getAssociatedObject(aGestureRecognizer, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey));
+  objc_setAssociatedObject(gestureRecognizers, delegate->deallocBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
+
+  objc_setAssociatedObject(self, AH_BRIDGE(UIGestureRecognizerSFGestureRecognizersPassingDelegateKey), nil, OBJC_ASSOCIATION_RETAIN);
+  if ([[CCDirector sharedDirector] respondsToSelector:@selector(view)]) {
+    [[[CCDirector sharedDirector] performSelector:@selector(view)] removeGestureRecognizer:aGestureRecognizer];
+  } else {
+    [[[CCDirector sharedDirector] performSelector:@selector(openGLView)] removeGestureRecognizer:aGestureRecognizer];
+  }
+  [gestureRecognizers removeObject:aGestureRecognizer];
+}
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (NSArray*)gestureRecognizers
+#else
+- (NSArray*)sf_gestureRecognizers
+#endif
+{
+  //! add to array
+  NSMutableArray *gestureRecognizers = objc_getAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersArrayKey));
+  if (!gestureRecognizers) {
+    gestureRecognizers = [NSMutableArray array];
+    objc_setAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersArrayKey), gestureRecognizers, OBJC_ASSOCIATION_RETAIN);
+  }
+  return [NSArray arrayWithArray: gestureRecognizers];
+}
+
+#pragma mark - Point inside
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (BOOL)isPointInArea:(CGPoint)pt
+#else
+- (BOOL)sf_isPointInArea:(CGPoint)pt
+#endif
+{
+  if (!_visible || !_isRunning)
+    return NO;
+
+  //! convert to local space 
+  pt = [self convertToNodeSpace:pt];
+  
+  //! get touchable rect in local space
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+  CGRect rect = self.touchRect;
+#else
+  CGRect rect = self.sf_touchRect;
+#endif
+  
+  if( CGRectContainsPoint(rect,pt) )
+    return YES;
+  return NO;
+}
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (BOOL)isPointTouchableInArea:(CGPoint)pt
+{
+  if (!self.isTouchEnabled) {
+    return NO;
+  } else {
+    return [self isPointInArea:pt];
+  }
+}
+#else
+- (BOOL)sf_isPointTouchableInArea:(CGPoint)pt
+{
+  if (!self.sf_isTouchEnabled) {
+    return NO;
+  } else {
+    return [self sf_isPointInArea:pt];
+  }
+}
+#endif
+
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (BOOL)isNodeInTreeTouched:(CGPoint)pt
+#else
+- (BOOL)sf_isNodeInTreeTouched:(CGPoint)pt
+#endif
+{
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+  if( [self isPointTouchableInArea:pt] ) {
+     return YES;
+  }
+#else
+  if( [self sf_isPointTouchableInArea:pt] ) {
+    return YES;
+  }
+#endif
+  
+  BOOL rslt = NO;
+  CCNode* child;
+  CCARRAY_FOREACH(_children, child )
+  {
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+    if( [child isNodeInTreeTouched:pt] )
+#else
+    if( [child sf_isNodeInTreeTouched:pt] )
+#endif
+    {
+      rslt = YES;
+      break;
+    }
+  }
+  return rslt;
+}
+
+#pragma mark - Touch Enabled
+
+- (BOOL)sf_isTouchEnabled
+{
+  if ([self respondsToSelector:@selector(isTouchEnabled)]) {
+    return (BOOL)[self performSelector:@selector(isTouchEnabled)];
+  }
+  //! our own implementation
+  NSNumber *touchEnabled = objc_getAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersTouchEnabled));
+  if (!touchEnabled) {
+    [self sf_setIsTouchEnabled:NO];
+    return NO;
+  }
+  return [touchEnabled boolValue];
+}
+
+- (void)sf_setIsTouchEnabled:(BOOL)aTouchEnabled
+{
+  if ([self respondsToSelector:@selector(setIsTouchEnabled:)]) {
+    [self sf_setIsTouchEnabled:aTouchEnabled];
+    return;
+  }
+  
+  objc_setAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersTouchEnabled), [NSNumber numberWithBool:aTouchEnabled], OBJC_ASSOCIATION_RETAIN);
+}
+
+#pragma mark - Touch Rectangle
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (void)setTouchRect:(CGRect)aRect
+#else
+- (void)sf_setTouchRect:(CGRect)aRect
+#endif
+{
+  objc_setAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersTouchRect), [NSValue valueWithCGRect:aRect], OBJC_ASSOCIATION_RETAIN);
+}
+
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (CGRect)touchRect
+#else
+- (CGRect)sf_touchRect
+#endif
+{
+  NSValue *rectValue = objc_getAssociatedObject(self, AH_BRIDGE(CCNodeSFGestureRecognizersTouchRect));
+  if (rectValue) {
+    return [rectValue CGRectValue];
+  } else {
+    CGRect defaultRect = CGRectMake(0, 0, self.contentSize.width, self.contentSize.height);
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+    self.touchRect = defaultRect;
+#else 
+    self.sf_touchRect = defaultRect;
+#endif
+    return defaultRect;
+  }
+}
+
+//! CCLayer has implementation of isTouchEnabled / setIsTouchEnabled, so we only use our internal methods if we are NOT CCLayer subclass 
+#if SF_GESTURE_RECOGNIZERS_USE_SHORTHAND
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+  if (anInvocation.selector == @selector(isTouchEnabled)) {
+    anInvocation.selector = @selector(sf_isTouchEnabled);
+  } else if (anInvocation.selector == @selector(setIsTouchEnabled:)) {
+    anInvocation.selector = @selector(sf_setIsTouchEnabled:);
+  }
+  [anInvocation invokeWithTarget:self];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+  if (![self respondsToSelector:aSelector]) {
+    if (aSelector == @selector(isTouchEnabled)) {
+      return [self methodSignatureForSelector:@selector(sf_isTouchEnabled)]; 
+    } else if (aSelector == @selector(setIsTouchEnabled:)) {
+      return [self methodSignatureForSelector:@selector(sf_setIsTouchEnabled:)]; 
+    }
+  }
+  
+  return [super methodSignatureForSelector:aSelector];
+}
+#endif
+@end


### PR DESCRIPTION
[NSString containsString:] was introduced with iOS 8.
